### PR TITLE
do not se append after json ext bytes initialized with len num

### DIFF
--- a/command.go
+++ b/command.go
@@ -247,7 +247,7 @@ func getMPubBodyWithJsonExt(extList []*MsgExt, bodies [][]byte) (*bytes.Buffer, 
 	bodySize := 4
 	for i, b := range bodies {
 		extJsonBytes := extList[i].ToJson();
-		jsonExtBytesList = append(jsonExtBytesList, extJsonBytes)
+		jsonExtBytesList[i] = extJsonBytes
 		bodySize += len(b) + 4 + 2 + len(extJsonBytes)
 	}
 	body := make([]byte, 0, bodySize)


### PR DESCRIPTION
do not use append, after len of json ext bytes list initialized.