### PR TITLE
do not expire producer if pass in topic is NOT empty

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -931,6 +931,10 @@ func (self *TopicProducerMgr) queryLookupd(newTopic string) {
 		self.topics[topicName] = newProducerInfo
 		self.topicMtx.Unlock()
 	}
+	//leave removing expired producer to timer
+	if newTopic != "" {
+		return
+	}
 	self.producerMtx.Lock()
 	if len(allTopicParts) > 0 {
 		for k, p := range self.producers {


### PR DESCRIPTION
address issue #5, by stopping add new topic action from expiring producer.
Signed-off-by: lulin@youzan.com <lulin@youzan.com>