### PR TITLE
remove topic partitions after removing a producer successfully

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -50,6 +50,10 @@ func (self *NsqdlookupdWrapper) fakeListLookupdWrap(w http.ResponseWriter, r *ht
 	w.Write([]byte("{}"))
 }
 
+func (self *NsqdlookupdWrapper) fakeListLookupdWrapSupplier(response string) func(http.ResponseWriter, *http.Request) {
+	return func (w http.ResponseWriter, r *http.Request) {w.Write([]byte(response))}
+}
+
 func (self *NsqdlookupdWrapper) fakeLookupdWrap(w http.ResponseWriter, r *http.Request) {
 	reqParams, err := url.ParseQuery(r.URL.RawQuery)
 	if err != nil {

--- a/producer.go
+++ b/producer.go
@@ -956,6 +956,7 @@ func (self *TopicProducerMgr) queryLookupd(newTopic string) {
 		if time.Since(p.ts) > removingKeepTime {
 			self.log(LogLevelInfo, "removing producer %v finally stopped", p.producer.addr)
 			delete(self.removingProducers, k)
+			self.removePartitionsOnProducer(p.producer.addr)
 			cleanProducers[k] = p.producer
 		}
 	}
@@ -1064,8 +1065,7 @@ func (self *TopicProducerMgr) removeProducerForTopic(topic string, pid int, addr
 	self.topicMtx.Unlock()
 }
 
-func (self *TopicProducerMgr) removeProducer(addr string) {
-	self.log(LogLevelInfo, "removing producer %v ", addr)
+func (self *TopicProducerMgr) removePartitionsOnProducer(addr string){
 	self.topicMtx.Lock()
 	for topic, v := range self.topics {
 		newInfo := NewTopicPartProducerInfo(v.meta, v.isMetaValid)
@@ -1082,6 +1082,10 @@ func (self *TopicProducerMgr) removeProducer(addr string) {
 		self.topics[topic] = newInfo
 	}
 	self.topicMtx.Unlock()
+}
+func (self *TopicProducerMgr) removeProducer(addr string) {
+	self.log(LogLevelInfo, "removing producer %v ", addr)
+	self.removePartitionsOnProducer(addr)
 	self.producerMtx.Lock()
 	producer, ok := self.producers[addr]
 	if ok {


### PR DESCRIPTION
fix the issue that if lookup failed, one or more producers may be removed but their topic partitions will be still in self.topic and when next normal lookup response comes, the producers removed will not be added back to the list
